### PR TITLE
Add dev scripts and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # ToDoApp
-Make a toDo app on web for practice improvement
+
+A simple full‑stack Todo application built with a React client and an Express/MongoDB server.
+
+## Setup
+
+### Requirements
+
+- Node.js **18** or newer
+
+### Install Dependencies
+
+From the project root run:
+
+```bash
+npm install
+```
+
+Then install dependencies for the client and server:
+
+```bash
+(cd client && npm install)
+(cd server && npm install)
+```
+
+### Environment Variables
+
+Create a `.env` file inside the `server` directory based on `.env.example`:
+
+```bash
+cp server/.env.example server/.env
+```
+
+Edit the new `.env` file to configure your MongoDB connection and port.
+
+### Running the App
+
+Start the client and server in development mode with a single command:
+
+```bash
+npm run dev
+```
+
+This uses `concurrently` to run the React development server and the API server together. You can also run them individually with `npm run client` and `npm run server`.
+

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {},

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "start": "node server/server.js",
     "client": "npm --prefix client run dev",
-    "server": "npm --prefix server start"
+    "server": "npm --prefix server start",
+    "dev": "concurrently \"npm run server\" \"npm run client\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "nodemon server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- document Node version and setup steps
- add concurrently and dev script at the repo root
- use nodemon for the server dev script
- update Tailwind config to ES module syntax

## Testing
- `npm --prefix client run lint`
- `npm --prefix server test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e500d1c83219a4a14057a387c68