### PR TITLE
Add MIT License and update package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/client/package.json
+++ b/client/package.json
@@ -26,5 +26,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.4",
     "vite": "^6.3.5"
-  }
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   "devDependencies": {
     "concurrently": "^9.2.0",
     "prettier": "^3.6.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- add a LICENSE file with the MIT terms
- set `license` field to `MIT` in all package.json files

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix server test` *(fails: no test specified)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa357b8d883219e8faaba39a3542b