### PR TITLE
Add server-side error handler and request validation

### DIFF
--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,0 +1,10 @@
+module.exports = (err, req, res, _next) => {
+  void _next;
+  console.error(err);
+  const status = err.status || 500;
+  const response = { error: err.message || 'Internal Server Error' };
+  if (err.details) {
+    response.details = err.details;
+  }
+  res.status(status).json(response);
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "server",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-validator": "^6.14.3",
         "mongoose": "^8.16.0"
       },
       "devDependencies": {
@@ -997,6 +998,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "6.14.3",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.3.tgz",
+      "integrity": "sha512-c4b9NMdhskfcLbH/FchsSfCt4Vb14gKzcotG9zLS+VoOJDox57aGhCL+kmAu7cl+ytaSed+HD5jdJhel8DQsdg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1478,6 +1492,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2312,6 +2332,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,12 +17,13 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-validator": "^6.14.3",
     "mongoose": "^8.16.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10",
     "@eslint/js": "^9.25.0",
     "eslint": "^9.25.0",
-    "globals": "^16.0.0"
+    "globals": "^16.0.0",
+    "nodemon": "^3.1.10"
   }
 }

--- a/server/routes/todos.js
+++ b/server/routes/todos.js
@@ -1,47 +1,77 @@
 const router = require('express').Router();
+const { body, param, validationResult } = require('express-validator');
 const Todo = require('../models/Todo');
 
+function handleValidation(req) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    const err = new Error('Validation failed');
+    err.status = 400;
+    err.details = errors.array();
+    throw err;
+  }
+}
+
 // Get all todos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
   try {
     const todos = await Todo.find();
     res.json(todos);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 });
 
 // Create a todo
-router.post('/', async (req, res) => {
-  try {
-    const todo = await Todo.create({ text: req.body.text });
-    res.status(201).json(todo);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+router.post(
+  '/',
+  body('text').trim().notEmpty().withMessage('Text is required'),
+  async (req, res, next) => {
+    try {
+      handleValidation(req);
+      const todo = await Todo.create({ text: req.body.text });
+      res.status(201).json(todo);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 // Toggle complete
-router.put('/:id', async (req, res) => {
-  try {
-    const todo = await Todo.findById(req.params.id);
-    if (!todo) return res.status(404).json({ error: 'Todo not found' });
-    todo.completed = !todo.completed;
-    await todo.save();
-    res.json(todo);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+router.put(
+  '/:id',
+  param('id').isMongoId().withMessage('Invalid todo id'),
+  async (req, res, next) => {
+    try {
+      handleValidation(req);
+      const todo = await Todo.findById(req.params.id);
+      if (!todo) {
+        const error = new Error('Todo not found');
+        error.status = 404;
+        throw error;
+      }
+      todo.completed = !todo.completed;
+      await todo.save();
+      res.json(todo);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 // Delete a todo
-router.delete('/:id', async (req, res) => {
-  try {
-    await Todo.findByIdAndDelete(req.params.id);
-    res.json({ success: true });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+router.delete(
+  '/:id',
+  param('id').isMongoId().withMessage('Invalid todo id'),
+  async (req, res, next) => {
+    try {
+      handleValidation(req);
+      await Todo.findByIdAndDelete(req.params.id);
+      res.json({ success: true });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,8 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 require('dotenv').config();
 
+const errorHandler = require('./middleware/errorHandler');
+
 const app = express();
 const PORT = process.env.PORT || 5000;
 
@@ -21,6 +23,8 @@ db.once('open', () => console.log('Connected to MongoDB'));
 
 // Routes
 app.use('/api/todos', require('./routes/todos'));
+
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- add Express error handler middleware
- validate todo routes and throw errors instead of sending from catch blocks
- register the new middleware in `server.js`
- add `express-validator` dependency

## Testing
- `npm --prefix server run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aa4cc19e48321b84d5de35bd51e23